### PR TITLE
Issue 5 - query parameter replacement not handled well in all cases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,13 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <profiles>

--- a/src/main/java/br/com/svvs/jdbc/redis/RedisPreparedStatement.java
+++ b/src/main/java/br/com/svvs/jdbc/redis/RedisPreparedStatement.java
@@ -54,7 +54,8 @@ public class RedisPreparedStatement extends RedisAbstractStatement implements Pr
         int idx = 1;
         while(this.sql.indexOf("?") > 1) {
             try {
-                this.sql = this.sql.replaceFirst("\\Q\u003F\\E", this.parameters.get(Integer.valueOf(idx)));
+                final String parameter = this.parameters.get(Integer.valueOf(idx));
+                this.sql = this.sql.replaceFirst("\\Q\u003F\\E", parameter==null ? "null" : parameter);
             } catch(IndexOutOfBoundsException e) {
                 throw new SQLException("Can't find defined parameter for position: " + idx);
             }

--- a/src/main/java/br/com/svvs/jdbc/redis/RedisPreparedStatement.java
+++ b/src/main/java/br/com/svvs/jdbc/redis/RedisPreparedStatement.java
@@ -26,6 +26,8 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.regex.Matcher.quoteReplacement;
+
 public class RedisPreparedStatement extends RedisAbstractStatement implements PreparedStatement {
 
     private Map<Integer,String> parameters = new HashMap<Integer,String>();
@@ -55,7 +57,7 @@ public class RedisPreparedStatement extends RedisAbstractStatement implements Pr
         while(this.sql.indexOf("?") > 1) {
             try {
                 final String parameter = this.parameters.get(Integer.valueOf(idx));
-                this.sql = this.sql.replaceFirst("\\Q\u003F\\E", parameter==null ? "null" : parameter);
+                this.sql = this.sql.replaceFirst("\\Q\u003F\\E", parameter==null ? "null" : quoteReplacement(parameter));
             } catch(IndexOutOfBoundsException e) {
                 throw new SQLException("Can't find defined parameter for position: " + idx);
             }

--- a/src/test/java/br/com/svvs/jdbc/redis/RedisPreparedStatementTest.java
+++ b/src/test/java/br/com/svvs/jdbc/redis/RedisPreparedStatementTest.java
@@ -1,0 +1,100 @@
+package br.com.svvs.jdbc.redis;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+public class RedisPreparedStatementTest {
+
+    public static final String MOCK_RESPONSE = "mockResult";
+
+    private RedisConnection connection;
+
+    @Before
+    public void before () throws Exception {
+        connection = Mockito.mock(RedisConnection.class);
+        when(connection.msgToServer(any(String.class))).thenReturn(MOCK_RESPONSE);
+    }
+
+    @Test
+    public void executeQueryWithoutParameters() {
+        try {
+            RedisPreparedStatement stmt = new RedisPreparedStatement("get {\"id\":10}", connection);
+            assertTrue(stmt.execute());
+            assertEquals("get {\"id\":10}", stmt.sql);
+            assertResultSetContainsMockedResponse(stmt);
+        }catch (Exception e){
+            Assert.fail("Failed with exception");
+        }
+    }
+    @Test
+    public void executeQueryWithIntegerParameter() {
+        try {
+            RedisPreparedStatement stmt = new RedisPreparedStatement("get {\"id\":?}", connection);
+            stmt.setInt(1, 1000);
+            assertTrue(stmt.execute());
+            assertEquals("get {\"id\":1000}", stmt.sql);
+            assertResultSetContainsMockedResponse(stmt);
+        }catch (Exception e){
+            Assert.fail("Failed with exception");
+        }
+    }
+
+    @Test
+    public void executeQueryWithNullParameter() {
+        try {
+            RedisPreparedStatement stmt = new RedisPreparedStatement("get {\"id\":?}", connection);
+            stmt.setString(1, null);
+            assertTrue(stmt.execute());
+            assertEquals("get {\"id\":null}", stmt.sql);
+            assertResultSetContainsMockedResponse(stmt);
+        }catch (Exception e){
+            Assert.fail("Failed with exception");
+        }
+    }
+
+    @Test
+    public void executeQueryWithIntAndStringParameters() {
+        try {
+            RedisPreparedStatement stmt = new RedisPreparedStatement("get {\"id\":?,type:\"?\"}", connection);
+            stmt.setInt(1, 1000);
+            stmt.setString(2, "test");
+            assertTrue(stmt.execute());
+            assertEquals("get {\"id\":1000,type:\"test\"}", stmt.sql);
+            assertResultSetContainsMockedResponse(stmt);
+        }catch (Exception e){
+            Assert.fail("Failed with exception");
+        }
+    }
+
+    @Test
+    public void executeQueryWithQuoteReplacementString() {
+        try {
+            RedisPreparedStatement stmt = new RedisPreparedStatement("get {\"id\":?,type:\"?\"}", connection);
+            stmt.setInt(1, 1000);
+            stmt.setString(2, "te$t");
+            assertTrue(stmt.execute());
+            assertEquals("get {\"id\":1000,type:\"te$t\"}", stmt.sql);
+            assertResultSetContainsMockedResponse(stmt);
+        }catch (Exception e){
+            Assert.fail("Failed with exception");
+        }
+    }
+
+    private void assertResultSetContainsMockedResponse(RedisPreparedStatement stmt) throws SQLException {
+        ResultSet resultSet = stmt.getResultSet();
+        resultSet.next();
+        assertNotNull(resultSet);
+        assertEquals(MOCK_RESPONSE, resultSet.getString(0));
+    }
+}


### PR DESCRIPTION
-Fixed an issue where parameter replacement result failed if the string parameter contained a \ or $ as per javadoc java.lang.String#replaceFirst
-Replace null parameters with the value null in the query
-Added tests for RedisPreparedStatement